### PR TITLE
feat(io_utils): add import and export endpoints and CLI for link data

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,12 @@ The algorithm ensures that:
 - View `/dashboard` to see links grouped by health status
 - Check `/stats` for database statistics
 
+### Import & Export
+- Use the **Need an offline backup?** callout on `/dashboard` to download CSV or JSON exports. Large libraries stream directly from SQLite, so leave the tab open until the browser finishes downloading.
+- The same card exposes an **Import links** form—upload a CSV/JSON file that follows the export schema (`id,name,url,rank,accessed,tags`). Provide an `id` to update an existing link or leave it blank to create a new entry; tags are rewritten to match the uploaded list.
+- Direct endpoints exist for automation: `GET /exports/csv` or `/exports/json` return attachments, and `POST /imports` accepts `multipart/form-data` with `format=csv|json` plus the uploaded file.
+- For headless deployments, run `uv run python -m services.io_utils csv -o backups/startpage-links.csv` (swap `csv` for `json`) to export locally, then `curl -F format=json -F upload=@startpage-links.json http://your-host/imports` to import without touching the UI.
+
 ### Frecency Settings
 - Visit `/settings` (or the navbar link) to adjust the links-per-page batch size and the max rank pool used during pruning
 - Settings are validated server-side and apply immediately; refresh open tabs to pick up changes

--- a/docs/index.html
+++ b/docs/index.html
@@ -99,6 +99,18 @@
                     </ul>
                 </div>
             </div>
+            <div class="col-md-6">
+                <div class="glass-panel h-100">
+                    <h3 class="h5">Import &amp; export</h3>
+                    <p class="text-muted">Admins can download backups and restore them from the dashboard banner. Exports stream via <code>/exports/csv</code> or <code>/exports/json</code>, while imports POST to <code>/imports</code> using the same schema.</p>
+                    <ul class="small">
+                        <li>CSV files use the header <code>id,name,url,rank,accessed,tags</code> with semicolon-delimited tags.</li>
+                        <li>JSON exports mirror the same schema with a <code>tags</code> array.</li>
+                        <li>Leave <code>id</code> blank to create a new link during import; provide an <code>id</code> to overwrite the name, URL, rank, accessed timestamp, and tags.</li>
+                        <li>Headless servers can run <code>uv run python -m services.io_utils csv -o backups/links.csv</code> to export and <code>curl -F format=csv -F upload=@links.csv http://host/imports</code> to restore.</li>
+                    </ul>
+                </div>
+            </div>
         </div>
     </section>
 

--- a/main.py
+++ b/main.py
@@ -1,19 +1,21 @@
 import asyncio
 import contextlib
 import sqlite3
+from datetime import datetime
 from math import ceil
 from time import time
 from typing import Dict, List, Optional
 
 import uvicorn
-from fastapi import BackgroundTasks, FastAPI, Form, HTTPException, Request
-from fastapi.responses import HTMLResponse, RedirectResponse
+from fastapi import BackgroundTasks, FastAPI, File, Form, HTTPException, Request, UploadFile
+from fastapi.responses import HTMLResponse, RedirectResponse, StreamingResponse
 from fastapi.templating import Jinja2Templates
 from packaging.version import parse
 from starlette.responses import FileResponse
 from fastapi.staticfiles import StaticFiles
 
 import services.db_utils as db_utils
+import services.io_utils as io_utils
 
 # Initialize the database, with the current app version.
 db_utils.init_db("2")
@@ -180,6 +182,14 @@ async def dashboard(request: Request, page: int = 0):
     tags = db_utils.get_all_tags()
     counts = db_utils.get_count()
     frecency = db_utils.get_frecency_config()
+    import_summary = None
+    if request.query_params.get("import") == "success":
+        try:
+            created = int(request.query_params.get("created", 0))
+            updated = int(request.query_params.get("updated", 0))
+        except ValueError:
+            created = updated = 0
+        import_summary = {"created": created, "updated": updated}
     return templates.TemplateResponse(
         "dashboard.html",
         template_context(
@@ -190,8 +200,44 @@ async def dashboard(request: Request, page: int = 0):
             all_tags=tags,
             counts=counts,
             frecency=frecency,
+            import_summary=import_summary,
         ),
     )
+
+
+@app.get("/exports/{format_name}")
+async def export_links(format_name: str):
+    normalized = format_name.lower()
+    if normalized not in {"csv", "json"}:
+        raise HTTPException(status_code=400, detail="Format must be 'csv' or 'json'.")
+    timestamp = datetime.utcnow().strftime("%Y%m%d-%H%M%S")
+    filename = f"startpage-links-{timestamp}.{normalized}"
+    media_type = "text/csv" if normalized == "csv" else "application/json"
+    stream = io_utils.export_db_links(normalized)
+    return StreamingResponse(
+        stream,
+        media_type=media_type,
+        headers={"Content-Disposition": f'attachment; filename="{filename}"'},
+    )
+
+
+@app.post("/imports")
+async def import_links_endpoint(format_name: str = Form(..., alias="format"), upload: UploadFile = File(...)):
+    normalized = format_name.lower()
+    if normalized not in {"csv", "json"}:
+        raise HTTPException(status_code=400, detail="Format must be 'csv' or 'json'.")
+    payload = await upload.read()
+    if not payload:
+        raise HTTPException(status_code=400, detail="Uploaded file is empty.")
+    try:
+        summary = io_utils.import_db_links(payload, normalized)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    redirect_url = (
+        app.url_path_for("dashboard")
+        + f"?import=success&created={summary['created']}&updated={summary['updated']}"
+    )
+    return RedirectResponse(redirect_url, status_code=303)
 
 
 # get next page of links for infinite scroll

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "startpage"
-version = "2.1.0"
+version = "2.1.1"
 description = ""
 authors = [{ name = "Brandon Leon", email = "brandonleon@pm.me" }]
 readme = "README.md"

--- a/services/io_utils.py
+++ b/services/io_utils.py
@@ -1,9 +1,357 @@
+import argparse
 import csv
+import io
+import json
+import sqlite3
+from pathlib import Path
+from time import time
+from typing import Dict, Iterable, Iterator, List, Optional, Sequence, Tuple
+from uuid import uuid4
+
 import services.db_utils as db_utils
 
+EXPORT_FIELDS = ("id", "name", "url", "rank", "accessed", "tags")
+VALID_FORMATS = {"csv", "json"}
 
-# export database links to csv file
-def export_db_links():
-    links = db_utils.get_links(0, 20000)
-    for link in links:
-       print(link)
+
+def _normalize_format(format_name: str) -> str:
+    normalized = (format_name or "").strip().lower()
+    if normalized not in VALID_FORMATS:
+        raise ValueError("Unsupported format. Choose 'csv' or 'json'.")
+    return normalized
+
+
+def _iter_link_rows(batch_size: int = 512) -> Iterator[Dict[str, object]]:
+    """
+    Yield each link row with its tags to keep memory usage predictable.
+    """
+    connection = sqlite3.connect(db_utils.db_path)
+    connection.row_factory = sqlite3.Row
+    cursor = connection.cursor()
+    cursor.execute(
+        """
+        SELECT l.id, l.name, l.url, l.rank, l.accessed, t.name AS tag_name
+        FROM links AS l
+        LEFT JOIN tag_link_map AS tlm ON l.id = tlm.link_id
+        LEFT JOIN tags AS t ON tlm.tag_id = t.id
+        ORDER BY l.accessed DESC, l.id ASC, t.name ASC
+        """
+    )
+    pending: Optional[Dict[str, object]] = None
+    try:
+        while True:
+            rows = cursor.fetchmany(batch_size)
+            if not rows:
+                break
+            for row in rows:
+                link_id = row["id"]
+                if pending and pending["id"] != link_id:
+                    yield pending
+                    pending = None
+                if pending is None:
+                    pending = {
+                        "id": link_id,
+                        "name": row["name"],
+                        "url": row["url"],
+                        "rank": float(row["rank"]),
+                        "accessed": int(row["accessed"]),
+                        "tags": [],
+                    }
+                tag_name = row["tag_name"]
+                if tag_name and tag_name not in pending["tags"]:
+                    pending["tags"].append(tag_name)
+    finally:
+        connection.close()
+    if pending:
+        yield pending
+
+
+def _stream_json(rows: Iterable[Dict[str, object]]) -> Iterator[bytes]:
+    yield b"["
+    first = True
+    for row in rows:
+        chunk = json.dumps(
+            {
+                "id": row["id"],
+                "name": row["name"],
+                "url": row["url"],
+                "rank": row["rank"],
+                "accessed": row["accessed"],
+                "tags": row.get("tags", []),
+            },
+            separators=(",", ":"),
+        ).encode("utf-8")
+        if first:
+            yield chunk
+            first = False
+        else:
+            yield b"," + chunk
+    yield b"]"
+
+
+def _stream_csv(rows: Iterable[Dict[str, object]]) -> Iterator[bytes]:
+    buffer = io.StringIO()
+    writer = csv.writer(buffer, lineterminator="\n")
+    writer.writerow(EXPORT_FIELDS)
+    yield buffer.getvalue().encode("utf-8")
+    buffer.seek(0)
+    buffer.truncate(0)
+    for row in rows:
+        tags: List[str] = list(row.get("tags", []))
+        writer.writerow(
+            [
+                row["id"],
+                row["name"],
+                row["url"],
+                row["rank"],
+                row["accessed"],
+                ";".join(tags),
+            ]
+        )
+        yield buffer.getvalue().encode("utf-8")
+        buffer.seek(0)
+        buffer.truncate(0)
+
+
+def _load_csv_rows(data: bytes) -> List[Dict[str, str]]:
+    text = data.decode("utf-8-sig")
+    reader = csv.DictReader(io.StringIO(text))
+    if reader.fieldnames is None:
+        raise ValueError("CSV upload is missing a header row.")
+    rows = list(reader)
+    if not rows:
+        raise ValueError("CSV upload does not contain any rows.")
+    return rows
+
+
+def _load_json_rows(data: bytes) -> List[Dict[str, object]]:
+    try:
+        payload = json.loads(data.decode("utf-8"))
+    except json.JSONDecodeError as exc:
+        raise ValueError("JSON upload could not be parsed.") from exc
+    if not isinstance(payload, list):
+        raise ValueError("JSON upload must be an array of link objects.")
+    if not payload:
+        raise ValueError("JSON upload does not contain any rows.")
+    rows: List[Dict[str, object]] = []
+    for idx, item in enumerate(payload, start=1):
+        if not isinstance(item, dict):
+            raise ValueError(f"JSON row {idx} is not an object.")
+        rows.append(item)
+    return rows
+
+
+def _normalize_tags(raw_tags: object) -> List[str]:
+    tags: List[str] = []
+    values: Sequence[str] = ()
+    if isinstance(raw_tags, str):
+        values = [part.strip() for part in raw_tags.split(";")]
+    elif isinstance(raw_tags, Sequence):
+        values = [str(part).strip() for part in raw_tags if str(part).strip()]
+    for value in values:
+        normalized = db_utils.normalize_tag(value)
+        if normalized and normalized not in tags:
+            tags.append(normalized)
+    return tags
+
+
+def _prepare_import_row(raw_row: Dict[str, object], index: int) -> Dict[str, object]:
+    def require(value: str, label: str) -> str:
+        cleaned = value.strip()
+        if not cleaned:
+            raise ValueError(f"Row {index}: {label} is required.")
+        return cleaned
+
+    link_id_value = str(raw_row.get("id") or "").strip()
+    link_id = link_id_value or None
+    name = require(str(raw_row.get("name", "")), "name")
+    url = require(str(raw_row.get("url", "")), "url")
+
+    rank_raw = raw_row.get("rank", 1.0)
+    try:
+        rank = float(rank_raw) if rank_raw not in ("", None) else 1.0
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"Row {index}: rank must be numeric.") from exc
+
+    accessed_raw = raw_row.get("accessed", int(time()))
+    try:
+        accessed = int(accessed_raw) if accessed_raw not in ("", None) else int(time())
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"Row {index}: accessed must be an integer timestamp.") from exc
+
+    tags = _normalize_tags(raw_row.get("tags"))
+    return {
+        "id": link_id,
+        "name": name,
+        "url": url,
+        "rank": rank,
+        "accessed": accessed,
+        "tags": tags,
+    }
+
+
+def _sync_tags(cursor: sqlite3.Cursor, link_id: str, tags: List[str]) -> None:
+    cursor.execute(
+        """
+        SELECT t.id, t.name
+        FROM tags AS t
+        INNER JOIN tag_link_map tlm ON t.id = tlm.tag_id
+        WHERE tlm.link_id = :link_id
+        """,
+        {"link_id": link_id},
+    )
+    existing_rows = cursor.fetchall()
+    existing: Dict[str, str] = {row["name"]: row["id"] for row in existing_rows}
+    target = set(tags)
+    # Remove tags no longer present
+    for current_name, tag_id in existing.items():
+        if current_name in target:
+            continue
+        cursor.execute(
+            "DELETE FROM tag_link_map WHERE tag_id = :tag_id AND link_id = :link_id",
+            {"tag_id": tag_id, "link_id": link_id},
+        )
+        cursor.execute(
+            "UPDATE tags SET count = (SELECT COUNT(*) FROM tag_link_map WHERE tag_id = :tag_id) WHERE id = :tag_id",
+            {"tag_id": tag_id},
+        )
+        cursor.execute(
+            "DELETE FROM tags WHERE id = :tag_id AND count = 0",
+            {"tag_id": tag_id},
+        )
+
+    # Add or update requested tags
+    for tag_name in tags:
+        if tag_name in existing:
+            continue
+        cursor.execute("SELECT id FROM tags WHERE name = :name", {"name": tag_name})
+        tag_row = cursor.fetchone()
+        if tag_row:
+            tag_id = tag_row["id"]
+        else:
+            tag_id = str(uuid4())
+            cursor.execute(
+                "INSERT INTO tags (id, name, count) VALUES (:id, :name, 0)",
+                {"id": tag_id, "name": tag_name},
+            )
+        cursor.execute(
+            "INSERT OR IGNORE INTO tag_link_map (tag_id, link_id) VALUES (:tag_id, :link_id)",
+            {"tag_id": tag_id, "link_id": link_id},
+        )
+        cursor.execute(
+            "UPDATE tags SET count = (SELECT COUNT(*) FROM tag_link_map WHERE tag_id = :tag_id) WHERE id = :tag_id",
+            {"tag_id": tag_id},
+        )
+
+
+def _upsert_link(cursor: sqlite3.Cursor, row: Dict[str, object]) -> Tuple[str, bool]:
+    link_id = row["id"] or str(uuid4())
+    cursor.execute("SELECT 1 FROM links WHERE id = :id", {"id": link_id})
+    exists = cursor.fetchone() is not None
+    params = {
+        "id": link_id,
+        "name": row["name"],
+        "url": row["url"],
+        "rank": row["rank"],
+        "accessed": row["accessed"],
+    }
+    if exists:
+        cursor.execute(
+            "UPDATE links SET name = :name, url = :url, rank = :rank, accessed = :accessed WHERE id = :id",
+            params,
+        )
+    else:
+        cursor.execute(
+            "INSERT INTO links (id, name, url, rank, accessed, expires_at) VALUES (:id, :name, :url, :rank, :accessed, NULL)",
+            params,
+        )
+    return link_id, exists
+
+
+def export_db_links(
+    format_name: Optional[str] = None, batch_size: int = 512
+) -> Iterator[Dict[str, object]] | Iterator[bytes]:
+    """
+    Export all links plus their tags.
+
+    When no format is provided a generator of dictionaries is returned. Passing
+    a supported format streams serialized bytes suitable for writing to disk or
+    piping directly to a response.
+    """
+    if format_name is None:
+        return _iter_link_rows(batch_size=batch_size)
+    normalized = _normalize_format(format_name)
+    rows = _iter_link_rows(batch_size=batch_size)
+    if normalized == "json":
+        return _stream_json(rows)
+    return _stream_csv(rows)
+
+
+def import_db_links(data: bytes, format_name: str) -> Dict[str, int]:
+    """
+    Import links from a CSV or JSON payload following the export schema.
+    """
+    if not data:
+        raise ValueError("Import payload is empty.")
+    normalized = _normalize_format(format_name)
+    raw_rows = _load_json_rows(data) if normalized == "json" else _load_csv_rows(data)
+    connection = sqlite3.connect(db_utils.db_path)
+    connection.row_factory = sqlite3.Row
+    cursor = connection.cursor()
+    created = 0
+    updated = 0
+    try:
+        for index, raw_row in enumerate(raw_rows, start=1):
+            prepared = _prepare_import_row(raw_row, index)
+            link_id, existed = _upsert_link(cursor, prepared)
+            _sync_tags(cursor, link_id, prepared["tags"])
+            if existed:
+                updated += 1
+            else:
+                created += 1
+        connection.commit()
+    except sqlite3.IntegrityError as exc:
+        connection.rollback()
+        raise ValueError("Import failed due to a database constraint violation.") from exc
+    finally:
+        connection.close()
+    return {"created": created, "updated": updated}
+
+
+def write_export_file(format_name: str, destination: Path, batch_size: int = 512) -> Path:
+    """
+    Write the requested export format to the provided destination path.
+    """
+    normalized = _normalize_format(format_name)
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    rows = _iter_link_rows(batch_size=batch_size)
+    stream = _stream_json(rows) if normalized == "json" else _stream_csv(rows)
+    with destination.open("wb") as handle:
+        for chunk in stream:
+            handle.write(chunk)
+    return destination
+
+
+def _cli():
+    parser = argparse.ArgumentParser(description="StartPage link export helper.")
+    parser.add_argument(
+        "format",
+        nargs="?",
+        default="csv",
+        choices=sorted(VALID_FORMATS),
+        help="Export format.",
+    )
+    parser.add_argument(
+        "-o",
+        "--output",
+        type=Path,
+        help="Destination file. Defaults to startpage-links.<format>.",
+    )
+    args = parser.parse_args()
+    output = args.output or Path(f"startpage-links.{args.format}")
+    write_export_file(args.format, output)
+    print(f"Wrote {output}")
+
+
+if __name__ == "__main__":
+    _cli()

--- a/services/test_io_utils.py
+++ b/services/test_io_utils.py
@@ -1,0 +1,121 @@
+import json
+import os
+import sqlite3
+from pathlib import Path
+from uuid import uuid4
+
+import pytest
+
+TEST_CONFIG_PATH = Path(__file__).resolve().parent / "test_config.toml"
+os.environ["STARTPAGE_CONFIG_PATH"] = str(TEST_CONFIG_PATH)
+
+import services.db_utils as db_utils  # noqa: E402
+from services import app_config  # noqa: E402
+from services import io_utils  # noqa: E402
+
+
+def setup_module(module):
+    if TEST_CONFIG_PATH.exists():
+        TEST_CONFIG_PATH.unlink()
+    app_config.reload_runtime_config()
+
+
+def teardown_module(module):
+    if TEST_CONFIG_PATH.exists():
+        TEST_CONFIG_PATH.unlink()
+    app_config.reload_runtime_config()
+
+
+def _create_link_with_tag(tag: str = "export-check"):
+    name = f"Export-{uuid4()}"
+    url = f"https://export.example/{uuid4()}"
+    link_id = db_utils.save_link(name, url)
+    db_utils.add_tag_to_link(link_id, tag)
+    return link_id, name, tag
+
+
+def _cleanup_link(link_id: str):
+    tags = db_utils.get_tags_for_link(link_id)
+    for tag in tags:
+        db_utils.remove_tag_from_link(link_id, tag["id"])
+    db_utils.delete_link(link_id)
+
+
+def test_export_db_links_yields_rows_with_tags():
+    link_id, name, tag = _create_link_with_tag()
+    rows = io_utils.export_db_links()
+    try:
+        collected = None
+        for row in rows:
+            if row["id"] == link_id:
+                collected = row
+                break
+        assert collected is not None
+        assert collected["name"] == name
+        assert tag in collected["tags"]
+    finally:
+        db_utils.delete_link(link_id)
+
+
+def test_export_db_links_serializes_csv_and_json():
+    link_id, name, tag = _create_link_with_tag("export-serialized")
+    try:
+        csv_payload = b"".join(io_utils.export_db_links("csv")).decode("utf-8")
+        assert "id,name,url,rank,accessed,tags" in csv_payload.splitlines()[0]
+        assert name in csv_payload
+        assert tag in csv_payload
+
+        json_payload = b"".join(io_utils.export_db_links("json")).decode("utf-8")
+        data = json.loads(json_payload)
+        match = next(item for item in data if item["id"] == link_id)
+        assert match["name"] == name
+        assert match["tags"] and tag in match["tags"]
+    finally:
+        db_utils.delete_link(link_id)
+
+
+def test_import_db_links_creates_rows_from_json():
+    unique_tag = f"import-json-{uuid4().hex[:6]}"
+    url = f"https://json-import.example/{uuid4()}"
+    payload = json.dumps(
+        [
+            {
+                "id": "",
+                "name": "JSON Import",
+                "url": url,
+                "rank": 4.2,
+                "accessed": 1700000000,
+                "tags": [unique_tag],
+            }
+        ]
+    ).encode("utf-8")
+    summary = io_utils.import_db_links(payload, "json")
+    assert summary["created"] == 1
+    record = db_utils.find_link_by_name("JSON Import")
+    assert record is not None
+    tags = db_utils.get_tags_for_link(record["id"])
+    assert any(tag["name"] == unique_tag for tag in tags)
+    _cleanup_link(record["id"])
+
+
+def test_import_db_links_updates_existing_via_csv():
+    link_id = db_utils.save_link("CSV Import Original", f"https://csv-import.example/{uuid4()}")
+    db_utils.add_tag_to_link(link_id, "old-tag")
+    csv_text = (
+        "id,name,url,rank,accessed,tags\n"
+        f"{link_id},CSV Import Updated,https://csv-import.example/updated,99.5,1700001000,new-tag;second-tag\n"
+    )
+    summary = io_utils.import_db_links(csv_text.encode("utf-8"), "csv")
+    assert summary["updated"] == 1
+
+    con = sqlite3.connect(db_utils.db_path)
+    cur = con.cursor()
+    cur.execute("SELECT name, url, rank, accessed FROM links WHERE id = ?", (link_id,))
+    row = cur.fetchone()
+    con.close()
+    assert row[0] == "CSV Import Updated"
+    assert abs(row[2] - 99.5) < 0.001
+    assert row[3] == 1700001000
+    tags = {tag["name"] for tag in db_utils.get_tags_for_link(link_id)}
+    assert tags == {"new-tag", "second-tag"}
+    _cleanup_link(link_id)

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -18,6 +18,38 @@
             <span class="stat-pill">Batch size: {{ frecency.batch_size }}</span>
             <span class="stat-pill">Max rank pool: {{ frecency.max_rank }}</span>
         </div>
+        {% if import_summary %}
+        <div class="alert alert-success bg-transparent border border-success-subtle text-success-emphasis small mt-4" role="status">
+            Imported {{ import_summary.created }} new links and updated {{ import_summary.updated }} existing entries.
+        </div>
+        {% endif %}
+        <div class="alert alert-warning bg-transparent border border-warning-subtle text-warning-emphasis small mt-4" role="status">
+            <div class="fw-semibold">Need an offline backup?</div>
+            <p class="mb-2">Exports stream directly from SQLite and may take several minutes for large libraries. Leave the tab open until the download finishes.</p>
+            <div class="d-flex flex-wrap gap-2">
+                <a class="btn btn-outline-warning btn-sm" href="/exports/csv">Download CSV</a>
+                <a class="btn btn-outline-warning btn-sm" href="/exports/json">Download JSON</a>
+            </div>
+        </div>
+        <form action="/imports" method="post" enctype="multipart/form-data" class="bg-transparent border border-info-subtle rounded-3 p-3 mt-3">
+            <div class="d-flex flex-column flex-lg-row gap-3 align-items-lg-end">
+                <div class="flex-grow-1">
+                    <label for="import-upload" class="form-label small text-muted mb-1">Import CSV or JSON</label>
+                    <input type="file" class="form-control" id="import-upload" name="upload" accept=".csv,.json,text/csv,application/json" required>
+                </div>
+                <div>
+                    <label for="import-format" class="form-label small text-muted mb-1">Format</label>
+                    <select class="form-select" id="import-format" name="format" required>
+                        <option value="csv">CSV (id,name,url,rank,accessed,tags)</option>
+                        <option value="json">JSON (array of link objects)</option>
+                    </select>
+                </div>
+                <div class="d-flex align-items-end">
+                    <button class="btn btn-info" type="submit">Import links</button>
+                </div>
+            </div>
+            <div class="form-text">Leave the ID blank to create a new link. Matching IDs overwrite the name, URL, rank, accessed timestamp, and tag list.</div>
+        </form>
     </section>
 
     <form action="/dashboard/bulk-delete" method="post" id="bulk-action-form" class="d-flex flex-column gap-4">

--- a/templates/help.html
+++ b/templates/help.html
@@ -57,6 +57,15 @@
         </ul>
     </section>
 
+    <section class="glass-panel mb-4">
+        <h2 class="h5 mb-3">Import &amp; export</h2>
+        <ul class="mb-0">
+            <li><strong>Export anytime:</strong> The dashboard banner links to <code>/exports/csv</code> and <code>/exports/json</code>. CSV files include <code>id,name,url,rank,accessed,tags</code> (semicolon-separated tags) and JSON returns an array with the same fields.</li>
+            <li><strong>Import in bulk:</strong> Use the “Import links” form on <code>/dashboard</code> (or POST to <code>/imports</code>) with a matching CSV or JSON payload. Provide an <code>id</code> to update an existing link; leave it blank to create a new one.</li>
+            <li><strong>CLI workflows:</strong> Headless installs can run <code>uv run python -m services.io_utils csv -o backups/startpage-links.csv</code> to export, then <code>curl -F format=json -F upload=@links.json http://your-host/imports</code> (or csv) to re-import without touching the UI.</li>
+        </ul>
+    </section>
+
     <section class="glass-panel">
         <h2 class="h5 mb-3">Stay organized with tags</h2>
         <div class="row g-4">

--- a/test_exports.py
+++ b/test_exports.py
@@ -1,0 +1,121 @@
+import json
+import sqlite3
+from uuid import uuid4
+
+import httpx
+import pytest
+
+import main
+import services.db_utils as db_utils
+
+
+@pytest.fixture
+def export_link():
+    name = f"ExportRoute-{uuid4()}"
+    url = f"https://route-export.example/{uuid4()}"
+    link_id = db_utils.save_link(name, url)
+    tag = f"route-tag-{uuid4().hex[:6]}"
+    db_utils.add_tag_to_link(link_id, tag)
+    yield {"id": link_id, "tag": tag, "name": name}
+    db_utils.delete_link(link_id)
+
+
+def _cleanup_link(link_id: str):
+    tags = db_utils.get_tags_for_link(link_id)
+    for tag in tags:
+        db_utils.remove_tag_from_link(link_id, tag["id"])
+    db_utils.delete_link(link_id)
+
+
+@pytest.mark.anyio
+async def test_exports_json_route_returns_payload(export_link):
+    transport = httpx.ASGITransport(app=main.app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as client:
+        response = await client.get("/exports/json")
+    assert response.status_code == 200
+    assert response.headers["content-disposition"].endswith('.json"')
+    payload = response.json()
+    match = next(item for item in payload if item["id"] == export_link["id"])
+    assert match["name"] == export_link["name"]
+    assert export_link["tag"] in match["tags"]
+
+
+@pytest.mark.anyio
+async def test_exports_csv_route_streams_attachment(export_link):
+    transport = httpx.ASGITransport(app=main.app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as client:
+        response = await client.get("/exports/csv")
+    assert response.status_code == 200
+    assert response.headers["content-disposition"].endswith('.csv"')
+    lines = response.text.splitlines()
+    assert lines[0] == "id,name,url,rank,accessed,tags"
+    assert any(export_link["tag"] in line for line in lines[1:])
+
+
+@pytest.mark.anyio
+async def test_exports_invalid_format_returns_400():
+    transport = httpx.ASGITransport(app=main.app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as client:
+        response = await client.get("/exports/yaml")
+    assert response.status_code == 400
+    assert json.loads(response.content).get("detail")
+
+
+@pytest.mark.anyio
+async def test_import_route_creates_link_from_csv():
+    unique_name = f"Route Import {uuid4().hex[:6]}"
+    csv_payload = f"id,name,url,rank,accessed,tags\n,{unique_name},https://route-import.example/,3.1,1700000001,route-tag".encode(
+        "utf-8"
+    )
+    transport = httpx.ASGITransport(app=main.app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as client:
+        response = await client.post(
+            "/imports",
+            data={"format": "csv"},
+            files={"upload": ("links.csv", csv_payload, "text/csv")},
+        )
+    assert response.status_code == 303
+    created = db_utils.find_link_by_name(unique_name)
+    assert created is not None
+    tags = db_utils.get_tags_for_link(created["id"])
+    assert any(tag["name"] == "route-tag" for tag in tags)
+    _cleanup_link(created["id"])
+
+
+@pytest.mark.anyio
+async def test_import_route_updates_existing_json():
+    original_name = f"Import Route Existing {uuid4().hex[:6]}"
+    link_id = db_utils.save_link(original_name, f"https://import-existing.example/{uuid4()}")
+    db_utils.add_tag_to_link(link_id, "legacy-tag")
+    payload = json.dumps(
+        [
+            {
+                "id": link_id,
+                "name": "Import Route Updated",
+                "url": "https://import-existing.example/updated",
+                "rank": 12.5,
+                "accessed": 1900000000,
+                "tags": ["route-updated"],
+            }
+        ]
+    ).encode("utf-8")
+    transport = httpx.ASGITransport(app=main.app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as client:
+        response = await client.post(
+            "/imports",
+            data={"format": "json"},
+            files={"upload": ("links.json", payload, "application/json")},
+        )
+    assert response.status_code == 303
+    con = sqlite3.connect(db_utils.db_path)
+    cur = con.cursor()
+    cur.execute("SELECT name, url, rank, accessed FROM links WHERE id = ?", (link_id,))
+    row = cur.fetchone()
+    con.close()
+    assert row[0] == "Import Route Updated"
+    assert row[1] == "https://import-existing.example/updated"
+    assert abs(row[2] - 12.5) < 0.01
+    assert row[3] == 1900000000
+    tags = {tag["name"] for tag in db_utils.get_tags_for_link(link_id)}
+    assert tags == {"route-updated"}
+    _cleanup_link(link_id)

--- a/uv.lock
+++ b/uv.lock
@@ -507,7 +507,7 @@ wheels = [
 
 [[package]]
 name = "startpage"
-version = "2.1.0"
+version = "2.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
• Import/Export Pipeline

  - FastAPI now exposes /exports/{format} and /imports so admins can stream CSV/JSON backups and upload bulk edits. Requests validate the format, stream database
    rows via io_utils, and redirect back to /dashboard with success counts (main.py:178, main.py:208). The dashboard banner gained download buttons, an import
    form, and a success alert so the workflow is visible in the UI (templates/dashboard.html:21).
  - services/io_utils.py was rewritten to handle chunked exports and validated imports: it iterates links with tags, streams CSV/JSON, parses uploads,
    upserts rows, and reconciles tag mappings; it also provides a CLI (services/io_utils.py:24, services/io_utils.py:271, services/io_utils.py:290, services/
    io_utils.py:321, services/io_utils.py:335).

  Documentation & Help

  - Added an “Import & Export” section to the README plus matching guidance in the docs site and /help, covering schemas, endpoints, and CLI usage so operators
    understand the new workflow (README.md:92, docs/index.html:104, templates/help.html:60).

  Test Coverage

  - Service-level tests verify that export_db_links streams tags correctly and that import_db_links creates or updates records for both JSON and CSV inputs
    (services/test_io_utils.py:44, services/test_io_utils.py:77, services/test_io_utils.py:101).
  - New ASGI tests exercise the FastAPI endpoints end-to-end—including invalid formats, CSV downloads, and multipart uploads that create or update links—to ensure
    route behavior matches expectations (test_exports.py:30, test_exports.py:64, test_exports.py:85).

  Versioning

  - Bumped the project/package version to 2.1.1 to capture the import/export release (pyproject.toml:3, uv.lock:507).
